### PR TITLE
feat: add comprehensive unit and integration tests for bullshit detector

### DIFF
--- a/packages/bullshit-detector/jest.config.js
+++ b/packages/bullshit-detector/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: [
+    '**/__tests__/**/*.test.ts',
+  ],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+  ],
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
+};

--- a/packages/bullshit-detector/package.json
+++ b/packages/bullshit-detector/package.json
@@ -23,13 +23,17 @@
   "author": "Josh Everett",
   "license": "MIT",
   "devDependencies": {
+    "@jest/globals": "^29.0.0",
     "@tsconfig/node22": "^22.0.0",
     "@tsconfig/node-ts": "^1.0.4",
+    "@types/jest": "^29.0.0",
     "@types/node": "^20.0.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.0.0",
     "jest": "^29.0.0",
+    "jest-environment-node": "^29.0.0",
+    "ts-jest": "^29.0.0",
     "typescript": "5.9.2"
   },
   "dependencies": {

--- a/packages/bullshit-detector/src/__tests__/detectBullshit.integration.test.ts
+++ b/packages/bullshit-detector/src/__tests__/detectBullshit.integration.test.ts
@@ -1,0 +1,270 @@
+import { detectBullshit, OpenAIMessage, BullshitDetector } from '../index';
+
+// Integration tests - these make real API calls to OpenAI
+// They require OPENAI_API_KEY to be set in environment
+describe('detectBullshit - Integration Tests', () => {
+  // Skip tests if no API key is available
+  const skipIfNoApiKey = process.env.OPENAI_API_KEY ? describe : describe.skip;
+
+  skipIfNoApiKey('Live API calls', () => {
+    beforeAll(() => {
+      if (!process.env.OPENAI_API_KEY) {
+        console.warn('OPENAI_API_KEY not set - skipping integration tests');
+      }
+    });
+
+    describe('String input integration tests', () => {
+      it('should correctly identify accurate scientific fact', async () => {
+        const result = await detectBullshit('Water boils at 100 degrees Celsius at sea level.');
+
+        expect(result).toMatchObject({
+          transcript: 'Water boils at 100 degrees Celsius at sea level.',
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have low bullshit level for accurate fact
+        expect(result.bullshitLevel).toBeLessThanOrEqual(2);
+        expect(result.confidence).toBeGreaterThanOrEqual(3);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+
+      it('should correctly identify false information', async () => {
+        const result = await detectBullshit('The sun revolves around the Earth.');
+
+        expect(result).toMatchObject({
+          transcript: 'The sun revolves around the Earth.',
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have high bullshit level for false information
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(3);
+        expect(result.confidence).toBeGreaterThanOrEqual(3);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+
+      it('should handle ambiguous or opinion-based statements', async () => {
+        const result = await detectBullshit('Pizza is the best food in the world.');
+
+        expect(result).toMatchObject({
+          transcript: 'Pizza is the best food in the world.',
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have reasonable confidence bounds for subjective statements
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+
+      it('should handle complex statements with multiple claims', async () => {
+        const result = await detectBullshit('Einstein developed the theory of relativity in 1905, and he also invented the telephone.');
+
+        expect(result).toMatchObject({
+          transcript: expect.stringContaining('Einstein'),
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should identify the false claim about the telephone
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(2);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+    });
+
+    describe('OpenAI message input integration tests', () => {
+      it('should process conversation context correctly', async () => {
+        const messages: OpenAIMessage[] = [
+          { role: 'user', content: 'Tell me about historical events.' },
+          { role: 'assistant', content: 'I can help with historical information. What specific period interests you?' },
+          { role: 'user', content: 'World War II ended in 1945.' }
+        ];
+
+        const result = await detectBullshit(messages);
+
+        expect(result).toMatchObject({
+          transcript: 'World War II ended in 1945.',
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have low bullshit level for accurate historical fact
+        expect(result.bullshitLevel).toBeLessThanOrEqual(2);
+        expect(result.confidence).toBeGreaterThanOrEqual(3);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+
+      it('should handle false claims in conversation context', async () => {
+        const messages: OpenAIMessage[] = [
+          { role: 'user', content: 'What do you know about space?' },
+          { role: 'assistant', content: 'I can share information about space and astronomy.' },
+          { role: 'user', content: 'Mars is closer to the sun than Mercury.' }
+        ];
+
+        const result = await detectBullshit(messages);
+
+        expect(result).toMatchObject({
+          transcript: 'Mars is closer to the sun than Mercury.',
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have high bullshit level for false astronomical fact
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(3);
+        expect(result.confidence).toBeGreaterThanOrEqual(3);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+
+      it('should handle conversation with no clear factual claims', async () => {
+        const messages: OpenAIMessage[] = [
+          { role: 'user', content: 'Hello, how are you?' },
+          { role: 'assistant', content: 'Hello! I\'m doing well, thank you for asking.' },
+          { role: 'user', content: 'That\'s great to hear!' }
+        ];
+
+        const result = await detectBullshit(messages);
+
+        expect(result).toMatchObject({
+          transcript: expect.any(String),
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          claim: expect.any(String),
+          summary: expect.any(String),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have low bullshit level and possibly lower confidence for non-factual content
+        expect(result.bullshitLevel).toBeLessThanOrEqual(2);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+    });
+
+    describe('Legacy class interface integration tests', () => {
+      it('should work with BullshitDetector class', async () => {
+        const detector = new BullshitDetector({
+          maxStatements: 1,
+          confidenceThreshold: 3
+        });
+
+        const result = await detector.evaluateClaim('The capital of France is Paris.');
+
+        expect(result).toMatchObject({
+          claim: expect.any(String),
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have low bullshit level for accurate geographical fact
+        expect(result.bullshitLevel).toBeLessThanOrEqual(1);
+        expect(result.confidence).toBeGreaterThanOrEqual(4);
+
+        // Validate numeric ranges
+        expect(result.bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(result.bullshitLevel).toBeLessThanOrEqual(5);
+        expect(result.confidence).toBeGreaterThanOrEqual(0);
+        expect(result.confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+
+      it('should work with analyzeTranscript method', async () => {
+        const detector = new BullshitDetector();
+
+        const results = await detector.analyzeTranscript('Gravity makes objects fall towards Earth.');
+
+        expect(Array.isArray(results)).toBe(true);
+        expect(results).toHaveLength(1);
+        expect(results[0]).toMatchObject({
+          claim: expect.any(String),
+          bullshitLevel: expect.any(Number),
+          confidence: expect.any(Number),
+          reasoning: expect.any(String),
+          truth: expect.any(String),
+        });
+
+        // Should have low bullshit level for accurate physics fact
+        expect(results[0].bullshitLevel).toBeLessThanOrEqual(1);
+        expect(results[0].confidence).toBeGreaterThanOrEqual(4);
+
+        // Validate numeric ranges
+        expect(results[0].bullshitLevel).toBeGreaterThanOrEqual(0);
+        expect(results[0].bullshitLevel).toBeLessThanOrEqual(5);
+        expect(results[0].confidence).toBeGreaterThanOrEqual(0);
+        expect(results[0].confidence).toBeLessThanOrEqual(5);
+      }, 15000);
+    });
+
+    describe('Error handling integration tests', () => {
+      it('should handle API errors gracefully', async () => {
+        // Temporarily remove API key to test error handling
+        const originalApiKey = process.env.OPENAI_API_KEY;
+        delete process.env.OPENAI_API_KEY;
+
+        try {
+          await expect(detectBullshit('test')).rejects.toThrow('OPENAI_API_KEY environment variable is required');
+        } finally {
+          // Restore API key
+          process.env.OPENAI_API_KEY = originalApiKey;
+        }
+      });
+    });
+  });
+});

--- a/packages/bullshit-detector/src/__tests__/detectBullshit.unit.test.ts
+++ b/packages/bullshit-detector/src/__tests__/detectBullshit.unit.test.ts
@@ -1,0 +1,300 @@
+import { jest } from '@jest/globals';
+import { detectBullshit, OpenAIMessage, BullshitDetectionResult } from '../index';
+
+// Mock OpenAI
+const mockCreate = jest.fn();
+jest.mock('openai', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: mockCreate,
+        },
+      },
+    })),
+  };
+});
+
+describe('detectBullshit - Unit Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.OPENAI_API_KEY = 'test-api-key';
+  });
+
+  describe('String input tests', () => {
+    it('should detect accurate factual statement with low bullshit level', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'Water freezes at 0 degrees Celsius.',
+              claim: 'Water freezes at 0 degrees Celsius',
+              summary: 'Statement about water freezing temperature',
+              bullshitLevel: 0,
+              confidence: 5,
+              reasoning: 'This is a well-established scientific fact',
+              truth: 'Water does indeed freeze at 0 degrees Celsius under standard atmospheric pressure'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      const result = await detectBullshit('Water freezes at 0 degrees Celsius.');
+
+      expect(result).toEqual({
+        transcript: 'Water freezes at 0 degrees Celsius.',
+        claim: 'Water freezes at 0 degrees Celsius',
+        summary: 'Statement about water freezing temperature',
+        bullshitLevel: 0,
+        confidence: 5,
+        reasoning: 'This is a well-established scientific fact',
+        truth: 'Water does indeed freeze at 0 degrees Celsius under standard atmospheric pressure'
+      });
+
+      // Verify OpenAI was called with correct parameters
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: expect.stringContaining('You are a fact-checking AI') },
+          { role: 'user', content: 'Water freezes at 0 degrees Celsius.' }
+        ],
+        temperature: 0.1,
+        max_tokens: 1000,
+      });
+    });
+
+    it('should detect false information with high bullshit level', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'The Earth is flat and scientists are lying about it.',
+              claim: 'The Earth is flat',
+              summary: 'Claim about Earth being flat',
+              bullshitLevel: 5,
+              confidence: 5,
+              reasoning: 'This contradicts overwhelming scientific evidence that Earth is spherical',
+              truth: 'The Earth is an oblate spheroid, not flat, as proven by extensive scientific evidence'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      const result = await detectBullshit('The Earth is flat and scientists are lying about it.');
+
+      expect(result.bullshitLevel).toBe(5);
+      expect(result.confidence).toBe(5);
+      expect(result.reasoning).toContain('contradicts overwhelming scientific evidence');
+    });
+  });
+
+  describe('OpenAI message input tests', () => {
+    it('should process OpenAI-formatted messages correctly', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'The moon landing was fake.',
+              claim: 'The moon landing was fake',
+              summary: 'Claim that moon landing was staged',
+              bullshitLevel: 4,
+              confidence: 4,
+              reasoning: 'This is a well-debunked conspiracy theory with no credible evidence',
+              truth: 'The Apollo moon landings were real, well-documented historical events'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      const messages: OpenAIMessage[] = [
+        { role: 'user', content: 'Did we really land on the moon?' },
+        { role: 'assistant', content: 'Yes, the Apollo missions successfully landed on the moon.' },
+        { role: 'user', content: 'The moon landing was fake.' }
+      ];
+
+      const result = await detectBullshit(messages);
+
+      expect(result.bullshitLevel).toBe(4);
+      expect(result.claim).toBe('The moon landing was fake');
+
+      // Verify the messages were formatted correctly
+      expect(mockCreate).toHaveBeenCalledWith({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: expect.stringContaining('You are a fact-checking AI that analyzes conversations') },
+          { role: 'user', content: 'Did we really land on the moon?' },
+          { role: 'assistant', content: 'Yes, the Apollo missions successfully landed on the moon.' },
+          { role: 'user', content: 'The moon landing was fake.' }
+        ],
+        temperature: 0.1,
+        max_tokens: 1000,
+      });
+    });
+
+    it('should handle empty message array', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: '',
+              claim: 'No factual claims found',
+              summary: 'Empty conversation',
+              bullshitLevel: 0,
+              confidence: 1,
+              reasoning: 'No content to evaluate',
+              truth: 'No claims to verify'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      const result = await detectBullshit([]);
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('Error handling tests', () => {
+    it('should throw error when OPENAI_API_KEY is missing', async () => {
+      delete process.env.OPENAI_API_KEY;
+
+      await expect(detectBullshit('test')).rejects.toThrow('OPENAI_API_KEY environment variable is required');
+    });
+
+    it('should throw error when OpenAI API call fails', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('API call failed'));
+
+      await expect(detectBullshit('test')).rejects.toThrow('Bullshit detection failed: API call failed');
+    });
+
+    it('should throw error when response has no content', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {}
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      await expect(detectBullshit('test')).rejects.toThrow('No response content from OpenAI');
+    });
+
+    it('should throw error when response is not valid JSON', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: 'not valid json'
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      await expect(detectBullshit('test')).rejects.toThrow('Failed to parse OpenAI response as JSON');
+    });
+
+    it('should throw error when response is missing required fields', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'test',
+              // missing other required fields
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      await expect(detectBullshit('test')).rejects.toThrow('Missing required field in response');
+    });
+
+    it('should throw error when bullshitLevel is out of range', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'test',
+              claim: 'test claim',
+              summary: 'test summary',
+              bullshitLevel: 10, // Invalid - should be 0-5
+              confidence: 3,
+              reasoning: 'test reasoning',
+              truth: 'test truth'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      await expect(detectBullshit('test')).rejects.toThrow('Invalid bullshitLevel: 10 (must be 0-5)');
+    });
+
+    it('should throw error when confidence is out of range', async () => {
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'test',
+              claim: 'test claim',
+              summary: 'test summary',
+              bullshitLevel: 3,
+              confidence: -1, // Invalid - should be 0-5
+              reasoning: 'test reasoning',
+              truth: 'test truth'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      await expect(detectBullshit('test')).rejects.toThrow('Invalid confidence: -1 (must be 0-5)');
+    });
+  });
+
+  describe('Legacy class interface tests', () => {
+    it('should support BullshitDetector class for backward compatibility', async () => {
+      const { BullshitDetector } = require('../index');
+
+      const mockResponse = {
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              transcript: 'Test transcript',
+              claim: 'Test claim',
+              summary: 'Test summary',
+              bullshitLevel: 2,
+              confidence: 4,
+              reasoning: 'Test reasoning',
+              truth: 'Test truth'
+            })
+          }
+        }]
+      };
+
+      mockCreate.mockResolvedValueOnce(mockResponse);
+
+      const detector = new BullshitDetector();
+      const result = await detector.evaluateClaim('Test claim');
+
+      expect(result).toEqual({
+        claim: 'Test claim',
+        bullshitLevel: 2,
+        confidence: 4,
+        reasoning: 'Test reasoning',
+        truth: 'Test truth'
+      });
+    });
+  });
+});

--- a/packages/bullshit-detector/src/__tests__/setup.ts
+++ b/packages/bullshit-detector/src/__tests__/setup.ts
@@ -1,0 +1,8 @@
+// Jest setup file for common test utilities and mocks
+import { jest } from '@jest/globals';
+
+// Set a default timeout for tests
+jest.setTimeout(30000);
+
+// Mock environment variables for tests
+process.env.OPENAI_API_KEY = 'test-api-key';


### PR DESCRIPTION
Resolves ##7

Adds comprehensive test coverage for the bullshit detector's `detectBullshit` function:

## Changes
- Add Jest configuration with TypeScript support
- Create unit tests with OpenAI API mocking for both string and message inputs
- Create integration tests for live API calls
- Add test cases for error handling and validation
- Support both detectBullshit function and legacy BullshitDetector class
- Add required Jest dependencies (@types/jest, ts-jest, etc.)

## Test Coverage
**Unit Tests** - Mock OpenAI API with static fixtures
**Integration Tests** - Live API calls (require OPENAI_API_KEY)

Both suites test string inputs, OpenAI message arrays, error handling, and legacy compatibility.

Generated with [Claude Code](https://claude.ai/code)