### PR TITLE
feat: add dotenv support to bullshit detector

### DIFF
--- a/packages/bullshit-detector/.env.example
+++ b/packages/bullshit-detector/.env.example
@@ -1,0 +1,2 @@
+# OpenAI API Key for bullshit detection
+OPENAI_API_KEY=your_openai_api_key_here

--- a/packages/bullshit-detector/package.json
+++ b/packages/bullshit-detector/package.json
@@ -37,7 +37,8 @@
     "typescript": "5.9.2"
   },
   "dependencies": {
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "dotenv": "^16.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/bullshit-detector/src/index.ts
+++ b/packages/bullshit-detector/src/index.ts
@@ -5,7 +5,11 @@
  * Uses OpenAI for single-call fact extraction and evaluation.
  */
 
+import { config } from 'dotenv';
 import OpenAI from 'openai';
+
+// Load environment variables from .env file
+config();
 
 export interface BullshitDetectionResult {
   transcript: string;


### PR DESCRIPTION
Add dotenv support to hydrate process.env usage in the bullshit detector package.

Changes:
- Add dotenv dependency to package.json
- Configure dotenv loading in src/index.ts
- Create .env.example with required environment variables

Closes #11

Generated with [Claude Code](https://claude.ai/code)