### PR TITLE
fix: update outdated package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "lint": "npm run lint --workspaces"
   },
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.7.2"
   }
 }

--- a/packages/bullshit-detector/package.json
+++ b/packages/bullshit-detector/package.json
@@ -25,16 +25,16 @@
   "devDependencies": {
     "@jest/globals": "^29.0.0",
     "@tsconfig/node22": "^22.0.0",
-    "@tsconfig/node-ts": "^1.0.4",
+    "@tsconfig/node-ts": "^23.6.1",
     "@types/jest": "^29.0.0",
-    "@types/node": "^20.0.0",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
-    "eslint": "^8.0.0",
+    "@types/node": "^22.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
     "jest": "^29.0.0",
     "jest-environment-node": "^29.0.0",
     "ts-jest": "^29.0.0",
-    "typescript": "5.9.2"
+    "typescript": "^5.7.2"
   },
   "dependencies": {
     "openai": "^4.0.0",


### PR DESCRIPTION
Fixes #19

Fixed multiple outdated package versions that were causing npm install to fail:

- Fixed `@tsconfig/node-ts` from ^1.0.4 to ^23.6.1 (main issue)
- Updated TypeScript ESLint packages to v8
- Updated ESLint to v9
- Updated @types/node to v22
- Updated TypeScript to v5.7.2

Generated with [Claude Code](https://claude.ai/code)