### PR TITLE
fix: respect existing environment variables in test setup

### DIFF
--- a/packages/bullshit-detector/src/__tests__/setup.ts
+++ b/packages/bullshit-detector/src/__tests__/setup.ts
@@ -4,5 +4,7 @@ import { vi } from 'vitest';
 // Set a default timeout for tests
 vi.setConfig({ testTimeout: 30000 });
 
-// Mock environment variables for tests
-process.env.OPENAI_API_KEY = 'test-api-key';
+// Set default test API keys only if real ones aren't present
+if (!process.env.OPENAI_API_KEY) {
+  process.env.OPENAI_API_KEY = 'test-api-key';
+}


### PR DESCRIPTION
Fixes integration tests failing with OpenAI API key errors by preventing test setup from overwriting real environment variables.

The test setup was unconditionally overwriting OPENAI_API_KEY with 'test-api-key', preventing integration tests from using real API keys from .env files.

Fixes #31

Generated with [Claude Code](https://claude.ai/code)