### PR TITLE
fix: prevent unit tests from overriding real API keys

### DIFF
--- a/packages/bullshit-detector/src/__tests__/detectBullshit.unit.test.ts
+++ b/packages/bullshit-detector/src/__tests__/detectBullshit.unit.test.ts
@@ -18,7 +18,10 @@ vi.mock('openai', () => {
 describe('detectBullshit - Unit Tests', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.OPENAI_API_KEY = 'test-api-key';
+    // Only set test API key if real one isn't present
+    if (!process.env.OPENAI_API_KEY) {
+      process.env.OPENAI_API_KEY = 'test-api-key';
+    }
   });
 
   describe('String input tests', () => {

--- a/packages/bullshit-detector/src/__tests__/factCheckAPIs.unit.test.ts
+++ b/packages/bullshit-detector/src/__tests__/factCheckAPIs.unit.test.ts
@@ -22,7 +22,10 @@ vi.mock('openai', () => {
 describe('External Fact-Checking APIs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env.OPENAI_API_KEY = 'test-api-key';
+    // Only set test API key if real one isn't present
+    if (!process.env.OPENAI_API_KEY) {
+      process.env.OPENAI_API_KEY = 'test-api-key';
+    }
   });
 
   describe('Configuration defaults', () => {


### PR DESCRIPTION
Fixes integration tests that were still failing with OpenAI API key errors despite the initial fix.

The issue was in the unit test files which had beforeEach hooks that unconditionally overwrote OPENAI_API_KEY with 'test-api-key'. Since Vitest runs all tests in the same process, these hooks were also running before integration tests, overriding real API keys.

Updated both unit test files to only set test API keys when real ones aren't present, ensuring integration tests can use real API keys from .env files.

Fixes #31

Generated with [Claude Code](https://claude.ai/code)