### PR TITLE
fix: load dotenv in test setup to respect .env file

### DIFF
--- a/packages/bullshit-detector/src/__tests__/setup.ts
+++ b/packages/bullshit-detector/src/__tests__/setup.ts
@@ -1,5 +1,9 @@
 // Vitest setup file for common test utilities and mocks
 import { vi } from 'vitest';
+import { config } from 'dotenv';
+
+// Load environment variables from .env file FIRST
+config();
 
 // Set a default timeout for tests
 vi.setConfig({ testTimeout: 30000 });
@@ -7,4 +11,8 @@ vi.setConfig({ testTimeout: 30000 });
 // Set default test API keys only if real ones aren't present
 if (!process.env.OPENAI_API_KEY) {
   process.env.OPENAI_API_KEY = 'test-api-key';
+}
+
+if (!process.env.GOOGLE_FACT_CHECK_API_KEY) {
+  process.env.GOOGLE_FACT_CHECK_API_KEY = 'test-google-key';
 }


### PR DESCRIPTION
Fixes integration tests failing with OpenAI API key errors by loading dotenv configuration in the test setup file.

The test setup file was not loading environment variables from .env files, causing integration tests to use fallback 'test-api-key' values instead of real API keys from the .env file.

Now the setup file loads dotenv.config() first, then only sets fallback values if real API keys aren't present.

Fixes #31

Generated with [Claude Code](https://claude.ai/code)