### PR TITLE
fix: repository configuration for npm publishing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Josh Everett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bullshit-detector/package.json
+++ b/packages/bullshit-detector/package.json
@@ -46,7 +46,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/josheverett/claude-playground.git",
+    "url": "https://github.com/josheverett/bullshit-detector.git",
     "directory": "packages/bullshit-detector"
+  },
+  "homepage": "https://github.com/josheverett/bullshit-detector#readme",
+  "bugs": {
+    "url": "https://github.com/josheverett/bullshit-detector/issues"
   }
 }


### PR DESCRIPTION
Addresses issue #42 - Repository Configuration tasks

## Changes
- Updated repository URL from claude-playground to bullshit-detector
- Added homepage and bugs URLs to package.json
- Added MIT LICENSE file at repo root
- Verified .gitignore is appropriate for npm publishing

Generated with [Claude Code](https://claude.ai/code)